### PR TITLE
Add a link to LITE with kernel 4.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This version of LITE has been tested for the following configuration:
 
 1. Software
   * OS: CentOS 7.1 (kernel `3.11.1` - also supports kernel `3.10.108`, but uses kernel `3.11.1` if possible)
+    * A port of LITE for kernel `4.9` can be found [here](https://github.com/lastweek/LITE).
   * RDMA drivers: `mlx4` from official libibverbs and verbs.
 2. Hardware
   * RNICs:


### PR DESCRIPTION
Hi Shin-Yeh,

This pull request wants to add a link to my ported version of LITE for kernel 4.9 and above. This port is known to work on: Ubuntu kernel 4.9.103 and mlx5. As long as OFED is not installed, it should be compatible with other settings as well.

It is hard to do in a #ifdef way, because I made a lot personal changes to trivial stuff. But if you prefer to do a patch way, let me know.