### PR TITLE
Remove imm_header_from_cq_to_port_cache kmem_free

### DIFF
--- a/core/lite_core.c
+++ b/core/lite_core.c
@@ -1627,7 +1627,6 @@ int client_receive_message(ltc *ctx, unsigned int port, void *ret_addr, int rece
 	node_id = new_request->source_node_id;
         //printk(KERN_CRIT "%s: offset %d node_id %d\n", __func__, offset, node_id);
 	//free list
-	kmem_cache_free(imm_header_from_cq_to_port_cache, new_request);
 
 	//get buffer from hash table based on node and port
 	port_node_key = (port<<MAX_NODE_BIT) + node_id;


### PR DESCRIPTION
This imm_header_from_cq_to_port_cache has never been used to do kmem_cache_alloc
thus this line will lead to BUG.